### PR TITLE
Hardening: canonical CSS + redirects + cleanupLifetime hardening

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -1,0 +1,18 @@
+/* Lifetime Home Services — Canonical overrides
+   Keep this AFTER Bootstrap CDN. Only global tweaks/brand rules go here. */
+
+html, body { scroll-behavior: smooth; }
+body { -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+
+:root{
+  --brand-primary:#ff6a00;   /* tweak as needed */
+  --brand-dark:#111111;
+}
+
+/* Example brand helpers (optional) */
+.text-brand { color: var(--brand-primary) !important; }
+.bg-brand   { background: var(--brand-primary) !important; }
+.btn-brand  { background: var(--brand-primary) !important; border-color: var(--brand-primary) !important; }
+.btn-brand:hover { filter: brightness(0.92); }
+
+/* Put your real overrides below as you refine the design */

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+        <link rel="stylesheet" href="/assets/css/site.css?v=1">
     <!-- Google Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     

--- a/lifetime/services/floor-coatings.html
+++ b/lifetime/services/floor-coatings.html
@@ -16,6 +16,7 @@
     <!-- Bootstrap 5 -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/assets/css/site.css?v=1">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     
     <style>

--- a/lifetime/services/floor-coatings/index.html
+++ b/lifetime/services/floor-coatings/index.html
@@ -6,7 +6,7 @@
 <title>Torginol Epoxy Floor Coatings | Lifetime Home Services</title>
 <meta name="description" content="Professional Torginol epoxy floor coatings with decorative flakes. 3-step process for garages, basements, and commercial spaces.">
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-<link href="/assets/css/site.css?v={{buildHash}}" rel="stylesheet">
+<link rel="stylesheet" href="/assets/css/site.css?v=1">
 <style>
 .hero-md{min-height:48vh;position:relative;display:flex;align-items:center}
 .hero-md .bg{position:absolute;inset:0;background:center/cover no-repeat}

--- a/lifetime/services/radon-mitigation.html
+++ b/lifetime/services/radon-mitigation.html
@@ -14,6 +14,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+        <link rel="stylesheet" href="/assets/css/site.css?v=1">
     <!-- Google Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     

--- a/lifetime/services/radon-mitigation/index.html
+++ b/lifetime/services/radon-mitigation/index.html
@@ -6,7 +6,7 @@
 <title>Radon Mitigation Systems That Work | Lifetime Home Services</title>
 <meta name="description" content="Custom radon mitigation designed for your home. Clean installs, quiet fans, post-install testing, and clear documentation.">
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-<link href="/assets/css/site.css?v={{buildHash}}" rel="stylesheet">
+<link rel="stylesheet" href="/assets/css/site.css?v=1">
 <style>
 .hero-md{min-height:48vh;position:relative;display:flex;align-items:center}
 .hero-md .bg{position:absolute;inset:0;background:center/cover no-repeat}

--- a/lifetime/services/radon-testing/index.html
+++ b/lifetime/services/radon-testing/index.html
@@ -6,7 +6,7 @@
   <title>Radon Testing for Wisconsin Homes | Lifetime Home Services</title>
   <meta name="description" content="Professional radon testing with accurate monitors, fast results, and clear next steps. Serving Wisconsin, Illinois, Minnesota & Colorado.">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="/assets/css/site.css?v={{buildHash}}" rel="stylesheet">
+    <link rel="stylesheet" href="/assets/css/site.css?v=1">
   <style>
     .hero-md {min-height: 48vh; position:relative; display:flex; align-items:center;}
     .hero-md .bg {position:absolute; inset:0; background:center/cover no-repeat;}

--- a/lifetime/services/struxure/index.html
+++ b/lifetime/services/struxure/index.html
@@ -6,7 +6,7 @@
 <title>StruXure Outdoor Living Pergolas | Lifetime Home Services</title>
 <meta name="description" content="Transform your outdoor space with StruXure motorized pergolas. Adjustable louvers, integrated lighting, and smart home compatibility.">
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-<link href="/assets/css/site.css?v={{buildHash}}" rel="stylesheet">
+<link rel="stylesheet" href="/assets/css/site.css?v=1">
 <style>
 .hero-md{min-height:48vh;position:relative;display:flex;align-items:center}
 .hero-md .bg{position:absolute;inset:0;background:center/cover no-repeat}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,20 @@
+[build]
+  publish = "."
+
+[[redirects]]
+  from = "/lifetime/styles.css"
+  to = "/assets/css/site.css"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/styles.css"
+  to = "/assets/css/site.css"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/*/styles.css"
+  to = "/assets/css/site.css"
+  status = 301
+  force = true

--- a/thank-you.html
+++ b/thank-you.html
@@ -10,6 +10,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+        <link rel="stylesheet" href="/assets/css/site.css?v=1">
     <!-- Google Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     


### PR DESCRIPTION
Add canonical stylesheet at /assets/css/site.css and reference it from all pages (after Bootstrap).

Remove assets.zip artifact.

Add Netlify redirects for legacy styles.css paths.

Acceptance checklist

 All HTML links to /assets/css/site.css (last stylesheet in <head>).

 No HTML references styles.css.

 /lifetime/styles.css 301s to the canonical CSS (via netlify.toml).

 Home and /lifetime/ still look correct (fonts, spacing, nav, hero).